### PR TITLE
exec: fix order of stack value extraction for copysign arguments

### DIFF
--- a/exec/num.go
+++ b/exec/num.go
@@ -377,7 +377,9 @@ func (vm *VM) f32Max() {
 }
 
 func (vm *VM) f32Copysign() {
-	vm.pushFloat32(float32(math.Copysign(float64(vm.popFloat32()), float64(vm.popFloat32()))))
+	v2 := vm.popFloat32()
+	v1 := vm.popFloat32()
+	vm.pushFloat32(float32(math.Copysign(float64(v1), float64(v2))))
 }
 
 func (vm *VM) f32Eq() {
@@ -472,7 +474,9 @@ func (vm *VM) f64Max() {
 }
 
 func (vm *VM) f64Copysign() {
-	vm.pushFloat64(math.Copysign(vm.popFloat64(), vm.popFloat64()))
+	v2 := vm.popFloat64()
+	v1 := vm.popFloat64()
+	vm.pushFloat64(math.Copysign(v1, v2))
 }
 
 func (vm *VM) f64Eq() {

--- a/exec/num_test.go
+++ b/exec/num_test.go
@@ -1,0 +1,68 @@
+// Copyright 2020 The go-interpreter Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package exec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-interpreter/wagon/wasm/operators"
+)
+
+func TestF32BinOps(t *testing.T) {
+	for _, tc := range []struct {
+		opcode byte
+		z1     float32
+		z2     float32
+		want   float32
+	}{
+		{operators.F32Sub, 3.0, 2.0, 1.0},
+		{operators.F32Copysign, 3.0, 2.0, 3.0},
+		{operators.F32Copysign, 3.0, -2.0, -3.0},
+	} {
+		name, err := operators.New(tc.opcode)
+		if err != nil {
+			t.Fatalf("could not lookup operator 0x%x: %+v", tc.opcode, name)
+		}
+		t.Run(fmt.Sprintf("%v(%v,%v)", name, tc.z1, tc.z2), func(t *testing.T) {
+			vm := new(VM)
+			vm.newFuncTable()
+			vm.pushFloat32(tc.z1)
+			vm.pushFloat32(tc.z2)
+			vm.funcTable[tc.opcode]()
+			if got, want := vm.popFloat32(), tc.want; got != want {
+				t.Fatalf("got=%v, want=%v", got, want)
+			}
+		})
+	}
+}
+
+func TestF64BinOps(t *testing.T) {
+	for _, tc := range []struct {
+		opcode byte
+		z1     float64
+		z2     float64
+		want   float64
+	}{
+		{operators.F64Sub, 3.0, 2.0, 1.0},
+		{operators.F64Copysign, 3.0, 2.0, 3.0},
+		{operators.F64Copysign, 3.0, -2.0, -3.0},
+	} {
+		name, err := operators.New(tc.opcode)
+		if err != nil {
+			t.Fatalf("could not lookup operator 0x%x: %+v", tc.opcode, name)
+		}
+		t.Run(fmt.Sprintf("%v(%v,%v)", name, tc.z1, tc.z2), func(t *testing.T) {
+			vm := new(VM)
+			vm.newFuncTable()
+			vm.pushFloat64(tc.z1)
+			vm.pushFloat64(tc.z2)
+			vm.funcTable[tc.opcode]()
+			if got, want := vm.popFloat64(), tc.want; got != want {
+				t.Fatalf("got=%v, want=%v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Values extracted from the stack for the copysign function were extracted (and thus used) in the wrong order.

This CL fixes this bug and adds tests for `float{32,64}`